### PR TITLE
Fix deprecation warning for mysql2

### DIFF
--- a/lib/database_url.rb
+++ b/lib/database_url.rb
@@ -6,7 +6,13 @@ require 'cgi'
 module DatabaseUrl
   class << self
     def to_active_record_hash(url = nil)
-      to_hash ACTIVE_RECORD_FIELD_MAP, url
+      result_hash = to_hash ACTIVE_RECORD_FIELD_MAP, url
+
+      if result_hash[:adapter] == 'mysql2'
+        result_hash[:username] = result_hash.delete(:user)
+      end
+
+      result_hash
     end
 
     def to_active_record_url(hash)

--- a/spec/database_url_spec.rb
+++ b/spec/database_url_spec.rb
@@ -45,6 +45,18 @@ describe DatabaseUrl do
         encoding: 'latin1',
       }
     end
+
+    it "builds config hashes for mysql2 without warnings" do
+      ENV['DATABASE_URL'] = "mysql2://user:xxx@127.0.0.1/dbname?encoding=utf8" # should be ignored!
+      DatabaseUrl.to_active_record_hash(ENV['DATABASE_URL']).should == {
+        adapter: 'mysql2',
+        host: '127.0.0.1',
+        database: 'dbname',
+        username: 'user',
+        password: 'xxx',
+        encoding: 'utf8',
+      }
+    end
   end
 
   describe 'Sequel' do


### PR DESCRIPTION
Related to this issue, I have a same problem https://github.com/seamusabshere/database_url/issues/2

For mysql2 scheme it will generate key `username` instead of `user`
